### PR TITLE
Make the search box work if you have a pathPrefix

### DIFF
--- a/index.11ty.js
+++ b/index.11ty.js
@@ -380,7 +380,17 @@ class Index extends Twitter {
 				if(urlInput && urlInput.value) {
 					var tweetIdMatch = urlInput.value.match(/\\/(\\d+)/);
 					if(tweetIdMatch && tweetIdMatch.length) {
-						document.location.href = "/" + tweetIdMatch[1] + "/";
+						/* make sure that our redirect honours any pathPrefix etc
+						   by allowing 11ty to rewrite a twitter link at build time
+						   and then reading and altering that rewritten link at runtime */
+						var redirect = "/1234567890123456789/";
+						var t = document.querySelector("template#rendered-twitter-link");
+						if (t && t.content) {
+							var a = t.content.querySelector("a");
+							if (a) redirect = a.href;
+						}
+						redirect = redirect.replace("1234567890123456789", tweetIdMatch[1]);
+						document.location.href = redirect;
 					}
 				}
 			}, false);
@@ -389,6 +399,7 @@ class Index extends Twitter {
 		var series = getSentimentsFromList( '#tweets-recent-home' );
 		makeSentimentChart( '.twtr-sentiment-chart', series );
 		</script>
+		<template id="rendered-twitter-link"><a href="/1234567890123456789/">twitter link</a></template>
 `;
 		// <h3>Before 2012, it was not possible to tell the difference between a mention and reply. This happened ${this.renderNumber(ambiguousReplyMentionCount)} times (${this.renderPercentage(ambiguousReplyMentionCount, tweetCount)})</h3>
 


### PR DESCRIPTION
The search box was hardcoded to redirect to a URL of /(tweetid)/ which is a problem if you're using a pathPrefix. Since tweetback uses the Base plugin to rewrite tweet URLs in accordance with a defined pathPrefix, we should use that. However, the code to do the redirect is in JS, not HTML. So we write out some invisible HTML in a <template> element, which contains an <a> with a link to a (made-up but valid-looking) tweet id. This gets rewritten at build time to be a link which respects the pathPrefix. Then, at runtime, we read the content of that link, and use it as a basis for the redirection. There may be an easier way to do this, by having the Base plugin rewrite a link in the JS itself, thus avoiding all the faffery with <template> elements, and if so, feel free to ignore this suggestion and do it a better way instead!