### PR TITLE
Optionally filter out Circle Tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,8 @@ If you want to fetch additional tweets from the API and put them into your sqlit
 1. You will need a twitter developer token an a `TWITTER_BEARER_TOKEN` environment variable (from the Twitter API v2).
 1. Run `npm run fetch-new-data`
 
+#### Exclude Tweets to Twitter Circles
+
+1. Before running `npm run import`, copy `./data/twitter-circle-tweet.js` from your Twitter Archive `zip` file into the `./database` directory of this project _(in addition to `tweets.js`)_.
+1. Rename `window.YTD.tweet.part0` in `twitter-circle-tweet.js` to `module.exports`
+1. Run `npm run import-without-circles`

--- a/database/import-from-archive.js
+++ b/database/import-from-archive.js
@@ -1,18 +1,32 @@
 require('dotenv').config();
 const { checkInDatabase, logTweetCount, saveToDatabaseApiV1, createTable } = require("./tweet-to-db");
+const shouldFilterOutCircleTweets = process.argv.includes('removeCircleTweets');
 const tweets = require("./tweets.js");
+let circleTweets;
+
+if (shouldFilterOutCircleTweets) {
+	circleTweets = require("./twitter-circle-tweet.js");
+}
 
 console.log( `${tweets.length} tweets found in archive.` );
 logTweetCount();
 
+function tweetIsForCircles(tweet) {
+	return circleTweets.some(circleTweet => circleTweet.tweet.id_str === tweet.id_str);
+}
+
 async function retrieveTweets() {
 	let existingRecordsFound = 0;
 	let missingTweets = 0;
+	let circleTweets = 0;
 
 	for(let {tweet} of tweets ) {
 		checkInDatabase(tweet).then((tweet) => {
 			if(tweet === false) {
 				existingRecordsFound++;
+			} else if (shouldFilterOutCircleTweets && tweetIsForCircles(tweet)) {
+				circleTweets++;
+				console.log( {circleTweets} );
 			} else {
 				missingTweets++;
 				saveToDatabaseApiV1(tweet);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "clean": "rm -rf .cache",
     "import": "node database/import-from-archive.js",
+    "import-without-circles": "npm run import -- removeCircleTweets",
     "fetch-new-data": "node database/fetchFromApi.js",
     "build": "npx @11ty/eleventy --quiet",
     "start": "npx @11ty/eleventy --quiet --serve"


### PR DESCRIPTION
Didn't mean to close #6, but to reiterate: 

- Not everyone wants to include semi-private Tweets (like those to Twitter Circles) in a published version of this project! 
- This allows users to optionally create the db file without Tweets to Twitter Circles.
- Adds a script to the `package.json` that just runs `import` with an additional argument. 
- Updates `README.md` with a section for explaining how to do the import without Circles Tweets.