### PR TITLE
Add support for YouTube embeds

### DIFF
--- a/src/twitter.js
+++ b/src/twitter.js
@@ -145,9 +145,22 @@ class Twitter {
 
 		// linkify urls
 		if( tweet.entities ) {
+			const YOUTUBE_ID_REGEX_PATTERN = /(?:youtube(?:-nocookie)?\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+
 			for(let url of tweet.entities.urls) {
 				if(url.expanded_url.indexOf(`/${tweet.id}/photo/`) > -1) { // || url.expanded_url.indexOf(`/${tweet.id}/video/`) > -1) {
 					text = text.replace(url.url, "");
+				} else if(YOUTUBE_ID_REGEX_PATTERN.test(url.expanded_url)) { //
+					const id = url.expanded_url.match(YOUTUBE_ID_REGEX_PATTERN)[1];
+					const searchParams = new URLSearchParams(new URL(url.expanded_url).search);
+
+					// Remove duplicate ID
+					if (searchParams.has('v')) {
+						searchParams.delete('v');
+					}
+
+					let displayUrlHtml = `<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/${id}${searchParams.keys().length ? '?' + searchParams.toString() : ''}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen crossorigin="anonymous" />`
+					text = text.replace(url.url, displayUrlHtml);
 				} else {
 					let {targetUrl, className, displayUrl} = this.getUrlObject(url);
 					targetUrl = twitterLink(targetUrl);


### PR DESCRIPTION
This PR adds basic support for YouTube embeds, so videos can be played directly. I could think of supporting other video services (e.g. Vimeo, Dailymotion), but I first wanted to see where this is going.

There are some shortcomings I don't want to leave unmentioned:

- this does not support YouTube playlist (Twitter itself only has limited support)
- the video ratio is fixed, but without accessing the YouTube API, there's no way to determine the correct one (16:9 is probably most common)

I also suggest applying [aspect-ratio](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) on the iFrame and maybe change the width/height in your CSS.