### PR TITLE
parseDomain returns topLevelDomains, not tld, and not always

### DIFF
--- a/src/twitter.js
+++ b/src/twitter.js
@@ -61,10 +61,17 @@ class Twitter {
 				try {
 					let urlObj = new URL(url.expanded_url ?? url.url);
 					let parsedDomain = parseDomain(urlObj.host);
+					let domain;
+					if (parsedDomain.topLevelDomains) {
+						const tld = parsedDomain.topLevelDomains.join(".");
+						domain = `${parsedDomain.domain}.${tld}`
+					} else {
+						domain = urlObj.host;
+					}
 					links.push({
 						host: urlObj.host,
 						origin: urlObj.origin,
-						domain: `${parsedDomain.domain}.${parsedDomain.tld}`
+						domain: domain
 					});
 				} catch(e) {
 					console.log( e );


### PR DESCRIPTION
The parseDomain() library returns an object with a `topLevelDomains` array (`['co', 'uk']` or similar), not a `tld` member. (Perhaps this is a breaking change from an earlier version.) This results in the "top domains" list being made of "twitter.undefined" entries and the like. Change to use `topLevelDomains` if present, or fall back to just the host if not.