### PR TITLE
Correctly parse hashtags in parens

### DIFF
--- a/index.11ty.js
+++ b/index.11ty.js
@@ -123,7 +123,7 @@ class Index extends Twitter {
 
 	getHashTagsFromText(text = "") {
 		let words = {};
-		let splits = text.split(/(\#[A-Za-z][^\s\.\'\"\!\,\?\;\}\{]*)/g);
+		let splits = text.split(/(\#[A-Za-z][^\s\.\'\"\!\,\?\;\}\{\)]*)/g);
 		for(let split of splits) {
 			if(split.startsWith("#")) {
 				let tag = split.substr(1).toLowerCase();

--- a/index.11ty.js
+++ b/index.11ty.js
@@ -1,4 +1,5 @@
 const swearjar = require("swearjar");
+const twitter = require("twitter-text");
 const metadata = require("./_data/metadata.js");
 const Twitter = require("./src/twitter");
 const EmojiAggregator = require( "./src/EmojiAggregator" );
@@ -123,15 +124,13 @@ class Index extends Twitter {
 
 	getHashTagsFromText(text = "") {
 		let words = {};
-		let splits = text.split(/(\#[A-Za-z][^\s\.\'\"\!\,\?\;\}\{\)]*)/g);
-		for(let split of splits) {
-			if(split.startsWith("#")) {
-				let tag = split.substr(1).toLowerCase();
-				if(!words[tag]) {
-					words[tag] = 0;
-				}
-				words[tag]++;
+		let hashtags = twitter.extractHashtags(text);
+		for(let hashtag of hashtags) {
+			let tag = hashtag.toLowerCase();
+			if(!words[tag]) {
+				words[tag] = 0;
 			}
+			words[tag]++;
 		}
 		return words;
 	}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "sentiment": "^5.0.2",
     "sqlite3": "^5.1.2",
     "swearjar": "^0.2.0",
-    "twitter-lite": "^1.1.0"
+    "twitter-lite": "^1.1.0",
+    "twitter-text": "^3.1.0"
   },
   "dependencies": {
     "@11ty/is-land": "^3.0.0",


### PR DESCRIPTION
I initially added to the regex so e.g. `(#hashtag)` is parsed as `#hashtag` not `#hashtag)` but then I realized it’s probably better to pull in the `twitter-text` package made by Twitter to use their logic for parsing hashtags. So that’s what this PR does.