### PR TITLE
Add support for the additional (missing) tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Take ownership of your Twitter data. First talked about at [Jamstack Conf 2019](
 
 1. Copy `./data/tweets.js` from your [Twitter Archive](https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive) `zip` file into the `./database` directory of this project.
    * Rename `window.YTD.tweet.part0` in `tweets.js` to `module.exports`
+1. If you `./data` directory includes any `tweets-part*.js` files, also copy these into `./database` and rename the `window.YTD.tweet.partX` (where `X` is a number) to `module.exports`
 1. If you want to exclude Twitter Circles tweets (these are included in the archive, why 😭): copy `./data/twitter-circle-tweet.js` from your Twitter Archive `zip` file into the `./database` directory of this project.
    * Rename `window.YTD.tweet.part0` in `twitter-circle-tweet.js` to `module.exports`
 1. Run `npm run import` or `npm run import-without-circles`

--- a/database/import-from-archive.js
+++ b/database/import-from-archive.js
@@ -2,6 +2,19 @@ require('dotenv').config();
 const { checkInDatabase, logTweetCount, saveToDatabaseApiV1, createTable } = require("./tweet-to-db");
 const shouldFilterOutCircleTweets = process.argv.includes('removecircletweets');
 const tweets = require("./tweets.js");
+
+// check for additional tweets (in the form of tweets-part1.js, etc)
+const extra = require("fs")
+  .readdirSync(__dirname)
+  .filter((_) => _.startsWith("tweets-part"));
+
+if (extra.length) {
+  for (let i = 0; i < extra.length; i++) {
+    const filename = extra[i];
+    tweets.push(...require("./" + filename));
+  }
+}
+
 let circleTweets;
 
 if (shouldFilterOutCircleTweets) {


### PR DESCRIPTION
My archive had 77,000 tweets, but the tweetback only pull in 67,000.

It turned out that my archive includes additional parts, in the form of tweets-part1.js. I'd guess that others with a larger archive will include additional files beyond part1, so I've added support for importing those missing files too.