### PR TITLE
Clarifying doc for the pathprefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Take ownership of your Twitter data. First talked about at [Jamstack Conf 2019](
 
 1. Edit the `_data/metadata.js` file to add metadata information.
 1. Run `npm run build` (will just create the proper files) or `npm start` (will run a server to look at them in your browser).
-1. _Optional:_ If you want the web site to live in a subdirectory (e.g. `/twitter/`), use [Eleventy’s Path Prefix feature](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix) via the command line `--pathprefix=twitter` or via a return object in your configuration file. Careful: this is an option to Eleventy and not npm, so it needs to live after a `--` separator (for instance, `npm run build -- --pathprefix=twitter`).
+	* _Optional:_ If you want the web site to live in a subdirectory (e.g. `/twitter/`), use [Eleventy’s Path Prefix feature](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix) via the command line `--pathprefix=twitter` or via a return object in your configuration file. Careful: this is an option to Eleventy and not npm, so it needs to live after a `--` separator (for instance, `npm run build -- --pathprefix=twitter`).
 
 ⚠️ _Warning_: the first build may take quite a long time (depending on the size of your archive), as remote media is fetched/downloaded into your project locally. Repeat builds will be much faster.
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Take ownership of your Twitter data. First talked about at [Jamstack Conf 2019](
 ### Build the web site
 
 1. Edit the `_data/metadata.js` file to add metadata information.
-1. _Optional:_ If you want the web site to live in a subdirectory (e.g. `/twitter/`), use [Eleventy’s Path Prefix feature](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix) via the command line `--pathprefix=twitter` or via a return object in your configuration file.
-1. Run `npm run build` or `npm start`
+1. Run `npm run build` (will just create the proper files) or `npm start` (will run a server to look at them in your browser).
+1. _Optional:_ If you want the web site to live in a subdirectory (e.g. `/twitter/`), use [Eleventy’s Path Prefix feature](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix) via the command line `--pathprefix=twitter` or via a return object in your configuration file. Careful: this is an option to Eleventy and not npm, so it needs to live after a `--` separator (for instance, `npm run build -- --pathprefix=twitter`).
 
 ⚠️ _Warning_: the first build may take quite a long time (depending on the size of your archive), as remote media is fetched/downloaded into your project locally. Repeat builds will be much faster.
 

--- a/docs/deploy-with-github-pages.md
+++ b/docs/deploy-with-github-pages.md
@@ -6,7 +6,7 @@ Use the following steps to deploy the generated archive to [GitHub pages](https:
 0. After creation, navigate to the Settings tab of your new GitHub repository
 0. Navigate to the "Pages" page
 0. Enable GitHub pages by selecting your `main` branch
-0. Follow the [instructions to Build the web site](https://github.com/tweetback/tweetback#build-the-web-site)
+0. Follow the [instructions to Build the web site](https://github.com/tweetback/tweetback#build-the-web-site). Note: unless you use a custom domain, you will need to pass your repo's name as your `--pathprefix` option.
 0. Using a terminal, navigate into the `_site` folder
 0. Run `git init`
 0. Add the new repository as the origin: `git remote add origin git@github.com:USERNAME/REPO.git`


### PR DESCRIPTION
I tripped up on this a bit, and thankfully I had some knowledge of NPM and of GitHub Pages that helped me past it, here's a change that would help people who don't.

The 3 changes:

- Passing a `--something` option directly to an npm command applies it to npm, and not the subtask being called (Eleventy in this case). A `--` separator must be used.
- Clarifying that the option is needed for GitHub Pages without custom domain, passing the repo's name as value. Should help the people who either (1) understand what the option does, but don't know what the GitHub Pages URL is, or (2) know the GitHub Pages URLs, but don't understand what the option is for.
- I also moved the optional instruction about `pathprefix` after the instruction to run npm commands rather than before, indented as a sub-bullet-point. This is because when I read I should use an option, it wasn't clear an option to what it was meant to be. Presenting the command first gives that context, and I'm hoping that indenting the bullet point means that people will read the optional advice before running the command (but I'd argue it wouldn't be a huge deal if they didn't anyway, and had to run the command again).