### PR TITLE
test: set up test infrastructure. refers to #71

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,16 @@
+# Ignore installed npm modules
 node_modules/
-.cache
-_site
-.env
+
+# Ignore build tool output, e.g. code coverage
+.nyc_output/
+coverage/
+
+# Ignore eleventy output when doing manual tests
+_site/
+
 package-lock.json
+
+# Ignore test files
+.cache
+
+.env

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "description": "Take ownership of your Twitter data and host your own Twitter archive.",
   "scripts": {
     "clean": "rm -rf .cache",
+    "coverage": "npx nyc ava && npx nyc report --reporter=json-summary",
     "import": "node database/import-from-archive.js",
     "import-without-circles": "npm run import -- removecircletweets",
     "fetch-new-data": "node database/fetchFromApi.js",
     "build": "npx @11ty/eleventy --quiet",
-    "start": "npx @11ty/eleventy --quiet --serve"
+    "start": "npx @11ty/eleventy --quiet --serve",
+    "test": "npx ava --verbose"
   },
   "keywords": [],
   "contributors": [
@@ -21,12 +23,14 @@
     "@11ty/eleventy-fetch": "^4.0.0",
     "@11ty/eleventy-img": "^3.1.1",
     "@tweetback/canonical": "^2.0.37",
+    "ava": "^6.1.3",
     "country-emoji": "^1.5.6",
     "dotenv": "^16.3.1",
     "emoji-regex": "^10.2.1",
     "entities": "^4.5.0",
     "lodash": "^4.17.21",
     "numeral": "^2.0.6",
+    "nyc": "^17.1.0",
     "pagefind": "^0.10.6",
     "parse-domain": "^5.0.0",
     "sentiment": "^5.0.2",

--- a/test/twitterTest.js
+++ b/test/twitterTest.js
@@ -1,0 +1,8 @@
+const test = require("ava");
+
+const Twitter = require("../src/twitter.js");
+
+test("Twitter can be instantiated", (t) => {
+	const twitter = new Twitter()
+	t.true(twitter instanceof Twitter)
+})


### PR DESCRIPTION
This is mirroring how the tests are structured in eleventy because both projects share maintainers. That being said I couldn't copy it 1:1, because I don't see CI like CircleCI or Coveralls configured.